### PR TITLE
Add suspension support

### DIFF
--- a/common/src/case_collection.py
+++ b/common/src/case_collection.py
@@ -10,6 +10,7 @@ class CaseStatus:
     FINISHED = 'FINISHED'
     SUSPENDED = 'SUSPENDED'
     ERROR = 'ERROR'
+    WAITING_SUSPENDED = 'WAITING_SUSPENDED'
 
 
 class CaseCollection:
@@ -53,12 +54,12 @@ class CaseCollection:
         case['_id'] = str(case['_id'])
         return case
 
-    def get_first_suspended(self):
+    def get_first_waiting_suspended(self):
         """
-        Fetches the first case where status is SUSPENDED, and sets status to EXECUTING
+        Fetches the first case where status is WAITING_SUSPENDED, and sets status to EXECUTING
         :return: The case object, or None if it does not exist or is already being executed.
         """
-        case = self.case_collection.find_one_and_update({'status': CaseStatus.SUSPENDED},
+        case = self.case_collection.find_one_and_update({'status': CaseStatus.WAITING_SUSPENDED},
                                                         {'$set': {'status': CaseStatus.EXECUTING}},
                                                         return_document=ReturnDocument.AFTER)
         if not case:

--- a/common/src/case_collection.py
+++ b/common/src/case_collection.py
@@ -43,10 +43,22 @@ class CaseCollection:
     def get_first_waiting(self):
         """
         Fetches the first case where status is WAITING, and sets status to EXECUTING
-        :param cid: The ID of the case.
         :return: The case object, or None if it does not exist or is already being executed.
         """
         case = self.case_collection.find_one_and_update({'status': CaseStatus.WAITING},
+                                                        {'$set': {'status': CaseStatus.EXECUTING}},
+                                                        return_document=ReturnDocument.AFTER)
+        if not case:
+            return None
+        case['_id'] = str(case['_id'])
+        return case
+
+    def get_first_suspended(self):
+        """
+        Fetches the first case where status is SUSPENDED, and sets status to EXECUTING
+        :return: The case object, or None if it does not exist or is already being executed.
+        """
+        case = self.case_collection.find_one_and_update({'status': CaseStatus.SUSPENDED},
                                                         {'$set': {'status': CaseStatus.EXECUTING}},
                                                         return_document=ReturnDocument.AFTER)
         if not case:

--- a/manager/src/main.py
+++ b/manager/src/main.py
@@ -53,9 +53,12 @@ def get_case_store(cid):
         'data': case['store']
     })
 
+
 @app.route('/<cid>/resume/', methods=['GET'], strict_slashes=False)
 def resume_case(cid):
     case = case_collection.get_case(cid)
+    if case['status'] != CaseStatus.SUSPENDED:
+        return 'Case is not suspended!', HTTPStatus.BAD_REQUEST
     case['status'] = CaseStatus.WAITING_SUSPENDED
     case_collection.update_case(cid, case)
     return '', HTTPStatus.OK

--- a/manager/src/main.py
+++ b/manager/src/main.py
@@ -30,7 +30,7 @@ def add_case(workflow, input_data):
     return case_collection.add_case(case)
 
 
-@app.route('/')
+@app.route('/', methods=['GET'])
 def get_all_cases():
     cases = case_collection.get_all_cases()
     return jsonify({
@@ -38,7 +38,7 @@ def get_all_cases():
     })
 
 
-@app.route('/<cid>')
+@app.route('/<cid>', methods=['GET'])
 def get_single_case(cid):
     case = case_collection.get_case(cid)
     return jsonify({
@@ -46,12 +46,19 @@ def get_single_case(cid):
     })
 
 
-@app.route('/<cid>/store')
+@app.route('/<cid>/store', methods=['GET'])
 def get_case_store(cid):
     case = case_collection.get_case(cid)
     return jsonify({
         'data': case['store']
     })
+
+@app.route('/<cid>/resume/', methods=['GET'], strict_slashes=False)
+def resume_case(cid):
+    case = case_collection.get_case(cid)
+    case['status'] = CaseStatus.WAITING_SUSPENDED
+    case_collection.update_case(cid, case)
+    return '', HTTPStatus.OK
 
 
 @app.route('/execute_workflow/<wid>', methods=['POST'])

--- a/worker/src/worker.py
+++ b/worker/src/worker.py
@@ -108,7 +108,7 @@ def evaluate_branch(case, step_item):
     return bool(eval(condition, {'__builtins__': None}, {}))
 
 
-def execute_case(case):
+def execute_case(case, was_suspended=False):
     """
     Handles the execution of a case, including the execution of single blocks and branching.
     :param cid: The case ID.
@@ -153,7 +153,13 @@ def execute_case(case):
 
 def main():
     while True:
-        case = case_collection.get_first_waiting()
+        # Try to fetch suspended cases first (takes priority over new cases)
+        case = case_collection.get_first_suspended()
+        if case:
+            print("Executing case", case['_id'], "(continued after suspension)")
+            execute_case(case, was_suspended=True)
+        else:
+            case = case_collection.get_first_waiting()
         if not case:
             time.sleep(5)
         else:

--- a/worker/src/worker.py
+++ b/worker/src/worker.py
@@ -156,7 +156,7 @@ def execute_case(case, was_suspended=False):
 def main():
     while True:
         # Try to fetch suspended cases first (takes priority over new cases)
-        case = case_collection.get_first_suspended()
+        case = case_collection.get_first_waiting_suspended()
         if case:
             print("Executing case", case['_id'], "(continued after suspension)")
             execute_case(case, was_suspended=True)

--- a/worker/src/worker.py
+++ b/worker/src/worker.py
@@ -130,9 +130,10 @@ def execute_case(case):
                     save_result(case, result, step_item)
                     step = step_item['next_block']
                 elif result['type'] == 'suspend':
-                    case['suspended'] = True
-                    # TODO Need to save state, and handle the reason for suspension
-                    pass
+                    case['status'] = CaseStatus.SUSPENDED
+                    case['state'] = result['state']
+                    case_collection.update_case(case['_id'], case)
+                    return
             elif step_item['type'] == 'branch':
                 step = step_item['next_block'][int(not evaluate_branch(case, step_item))]
 

--- a/worker/src/worker.py
+++ b/worker/src/worker.py
@@ -124,13 +124,15 @@ def execute_case(case, was_suspended=False):
                 result = execute_block(case, step_item, step, was_suspended)
 
                 # Delete any state information from the block, as we no longer need it
-                del case['state']
+                if 'state' in case:
+                    del case['state']
 
                 if not result:
                     return
 
                 if result['type'] == 'result':
-                    save_result(case, result, step_item)
+                    if 'save_outputs' in step_item:
+                        save_result(case, result, step_item)
                     step = step_item['next_block']
                 elif result['type'] == 'suspend':
                     case['status'] = CaseStatus.SUSPENDED


### PR DESCRIPTION
Adds support for suspension in the case executor. State is saved and the case is suspended. Then, when calling a special resume endpoint, the case is unsuspended and put in a special queue (takes priority over new cases). No handling of requested parameters in suspension at the moment.